### PR TITLE
Added EnableInterleaving support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mgwdev-m365-helpers",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mgwdev-m365-helpers",
-      "version": "0.2.2",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-browser": "3.6.0"

--- a/src/dal/dataProviders/SPSearchDataProvider.ts
+++ b/src/dal/dataProviders/SPSearchDataProvider.ts
@@ -14,6 +14,8 @@ export class SPSearchDataProvider<T> implements IPagedDataProvider<T>, IRefinabl
     protected aggregations?: IAggregationRequest[];
     protected filters?: IFilterRequest[];
     public cultureId: number = 1033;
+    public enableInterleaving: boolean = false
+
     constructor(protected searchApiUrl: string, protected httpClient: IHttpClient,
         public selectFields: string[],
         public serviceQuery: string) {
@@ -48,6 +50,7 @@ export class SPSearchDataProvider<T> implements IPagedDataProvider<T>, IRefinabl
         request.SortList = this.orderColumn && [{Direction: this.isDescending ? 0 : 1, Property: this.orderColumn || ""}]
         request.SelectProperties = this.selectFields;
         request.Culture = this.cultureId;
+        request.EnableInterleaving = this.enableInterleaving
         let requestBody = {
             request
         }

--- a/src/model/sharepoint/ISPSearchQuery.ts
+++ b/src/model/sharepoint/ISPSearchQuery.ts
@@ -16,4 +16,5 @@ export interface ISPSearchQuery {
     SortList?: { Direction: number, Property: string }[];
     TrimDuplicates: boolean;
     Culture?: number;
+    EnableInterleaving? :boolean;
 }


### PR DESCRIPTION
Added support for EnableInterleaving parameter. EnableInterleaving allows to ignore result blocks which are enabled in SP Rest APi by default. When result blocks are turned on some of search result may land in SecondaryQueryResults instead of PrimaryQueryResult. A case described here: https://www.techmikael.com/2023/04/there-are-still-new-things-to-learn.html