### PR TITLE
Add clearCache to IAuthenticationService

### DIFF
--- a/src/services/IAuthenticationService.ts
+++ b/src/services/IAuthenticationService.ts
@@ -2,4 +2,5 @@ export interface IAuthenticationService {
     getAccessToken(resource: string): Promise<string>;
     logout(): Promise<void>;
     isAuthenticated(): Promise<boolean>;
+    clearCache(): Promise<void>;
 }

--- a/src/services/MSAL2CustomAuthService.ts
+++ b/src/services/MSAL2CustomAuthService.ts
@@ -1,5 +1,6 @@
 import { queueRequest } from "../utils/FunctionUtils";
 import { generateGuid, generateRandomString } from "../utils/IdGenerator";
+import { MsalCacheUtils } from "../utils/MsalCacheUtils";
 import { TokenUtils } from "../utils/TokenUtils";
 import { IAuthenticationService } from "./IAuthenticationService";
 import { IMsalAuthenticationConfig } from "./Msal2AuthenticationService";
@@ -234,15 +235,7 @@ export class MSAL2CustomAuthService implements IAuthenticationService {
 
     public async clearCache(): Promise<void> {
         this.resourceTokenMap.clear();
-        const clientId = this.config.clientId;
-        for (const storage of [localStorage, sessionStorage]) {
-            const keys = Object.keys(storage);
-            for (const key of keys) {
-                if (key.startsWith(`msal.${clientId}.`) || key.includes(clientId)) {
-                    storage.removeItem(key);
-                }
-            }
-        }
+        MsalCacheUtils.clearStorageKeys(this.config.clientId);
     }
 
     @queueRequest("msal-access-token-{0}")

--- a/src/services/MSAL2CustomAuthService.ts
+++ b/src/services/MSAL2CustomAuthService.ts
@@ -232,6 +232,19 @@ export class MSAL2CustomAuthService implements IAuthenticationService {
         }
     }
 
+    public async clearCache(): Promise<void> {
+        this.resourceTokenMap.clear();
+        const clientId = this.config.clientId;
+        for (const storage of [localStorage, sessionStorage]) {
+            const keys = Object.keys(storage);
+            for (const key of keys) {
+                if (key.startsWith(`msal.${clientId}.`) || key.includes(clientId)) {
+                    storage.removeItem(key);
+                }
+            }
+        }
+    }
+
     @queueRequest("msal-access-token-{0}")
     public async getAccessToken(resource: string): Promise<string> {
         let token = this.resourceTokenMap.get(resource);

--- a/src/services/Msal2AuthenticationService.ts
+++ b/src/services/Msal2AuthenticationService.ts
@@ -98,6 +98,21 @@ export class Msal2AuthenticationService implements IAuthenticationService {
         }
     }
 
+    public async clearCache(): Promise<void> {
+        this.resourceTokenMap.clear();
+        await this.msalObj.initialize();
+        await this.msalObj.clearCache();
+        const clientId = this.config.clientId;
+        for (const storage of [localStorage, sessionStorage]) {
+            const keys = Object.keys(storage);
+            for (const key of keys) {
+                if (key.startsWith(`msal.${clientId}.`) || key.includes(clientId)) {
+                    storage.removeItem(key);
+                }
+            }
+        }
+    }
+
     public async isAuthenticated(): Promise<boolean> {
         await this.msalObj.initialize();
         const accounts = this.msalObj.getAllAccounts();

--- a/src/services/Msal2AuthenticationService.ts
+++ b/src/services/Msal2AuthenticationService.ts
@@ -1,4 +1,5 @@
 import { AuthenticationResult, InteractionRequiredAuthError, PublicClientApplication } from '@azure/msal-browser';
+import { MsalCacheUtils } from '../utils/MsalCacheUtils';
 import { TokenUtils } from '../utils/TokenUtils';
 import { IAuthenticationService } from './IAuthenticationService';
 import { queueRequest } from '../utils/FunctionUtils';
@@ -102,15 +103,7 @@ export class Msal2AuthenticationService implements IAuthenticationService {
         this.resourceTokenMap.clear();
         await this.msalObj.initialize();
         await this.msalObj.clearCache();
-        const clientId = this.config.clientId;
-        for (const storage of [localStorage, sessionStorage]) {
-            const keys = Object.keys(storage);
-            for (const key of keys) {
-                if (key.startsWith(`msal.${clientId}.`) || key.includes(clientId)) {
-                    storage.removeItem(key);
-                }
-            }
-        }
+        MsalCacheUtils.clearStorageKeys(this.config.clientId);
     }
 
     public async isAuthenticated(): Promise<boolean> {

--- a/src/services/MsalAuthenticationService.ts
+++ b/src/services/MsalAuthenticationService.ts
@@ -1,5 +1,6 @@
 import * as Msal from "msal";
 import { TokenUtils } from "../utils";
+import { MsalCacheUtils } from "../utils/MsalCacheUtils";
 import { queueRequest } from "../utils/FunctionUtils";
 import { IAuthenticationService } from "./IAuthenticationService";
 
@@ -57,14 +58,7 @@ export class MsalAuthenticationService implements IAuthenticationService {
 
     public async clearCache(): Promise<void> {
         this.resourceTokenMap.clear();
-        for (const storage of [localStorage, sessionStorage]) {
-            const keys = Object.keys(storage);
-            for (const key of keys) {
-                if (key.startsWith(`msal.${this.clientId}.`) || key.includes(this.clientId)) {
-                    storage.removeItem(key);
-                }
-            }
-        }
+        MsalCacheUtils.clearStorageKeys(this.clientId);
     }
 
     public async getAccessToken(resource: string = "https://graph.microsoft.com"): Promise<string> {

--- a/src/services/MsalAuthenticationService.ts
+++ b/src/services/MsalAuthenticationService.ts
@@ -55,6 +55,18 @@ export class MsalAuthenticationService implements IAuthenticationService {
         this.resourceTokenMap.clear();
     }
 
+    public async clearCache(): Promise<void> {
+        this.resourceTokenMap.clear();
+        for (const storage of [localStorage, sessionStorage]) {
+            const keys = Object.keys(storage);
+            for (const key of keys) {
+                if (key.startsWith(`msal.${this.clientId}.`) || key.includes(this.clientId)) {
+                    storage.removeItem(key);
+                }
+            }
+        }
+    }
+
     public async getAccessToken(resource: string = "https://graph.microsoft.com"): Promise<string> {
         let token = this.resourceTokenMap.get(resource);
         if (token && TokenUtils.isTokenValid(token)) {

--- a/src/services/NodeAppOnlyAuthenticationService.ts
+++ b/src/services/NodeAppOnlyAuthenticationService.ts
@@ -17,6 +17,10 @@ export class NodeAppOnlyAuthenticationService implements IAuthenticationService{
     public async logout(): Promise<void> {
     }
 
+    public async clearCache(): Promise<void> {
+        this.clientApp = new msal.ConfidentialClientApplication(this.msalConfig);
+    }
+
     public async isAuthenticated(): Promise<boolean> {
         return true;
     }

--- a/src/utils/MsalCacheUtils.ts
+++ b/src/utils/MsalCacheUtils.ts
@@ -1,0 +1,12 @@
+export class MsalCacheUtils {
+    public static clearStorageKeys(clientId: string): void {
+        for (const storage of [localStorage, sessionStorage]) {
+            const keys = Object.keys(storage);
+            for (const key of keys) {
+                if (key.startsWith(`msal.${clientId}.`) || key.includes(clientId)) {
+                    storage.removeItem(key);
+                }
+            }
+        }
+    }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,3 +5,4 @@ export * from "./TokenUtils";
 export * from "./DebounceHandler";
 export * from "./BlobUtils";
 export * from "./ImageHelper";
+export * from "./MsalCacheUtils";

--- a/tests/utils/MsalCacheUtils.test.ts
+++ b/tests/utils/MsalCacheUtils.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+///<reference types="jest" />
+import { MsalCacheUtils } from "../../src/utils/MsalCacheUtils";
+
+describe("MsalCacheUtils", () => {
+    const clientId = "11111111-1111-1111-1111-111111111111";
+    const otherClientId = "22222222-2222-2222-2222-222222222222";
+
+    beforeEach(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+    });
+
+    test("removes msal.<clientId>.* keys from localStorage", () => {
+        localStorage.setItem(`msal.${clientId}.https://graph.microsoft.com.idtoken`, "tok");
+        localStorage.setItem(`msal.${clientId}.account.keys`, "v");
+
+        MsalCacheUtils.clearStorageKeys(clientId);
+
+        expect(localStorage.getItem(`msal.${clientId}.https://graph.microsoft.com.idtoken`)).toBeNull();
+        expect(localStorage.getItem(`msal.${clientId}.account.keys`)).toBeNull();
+    });
+
+    test("removes msal.<clientId>.* keys from sessionStorage", () => {
+        sessionStorage.setItem(`msal.${clientId}.https://graph.microsoft.com.idtoken`, "tok");
+
+        MsalCacheUtils.clearStorageKeys(clientId);
+
+        expect(sessionStorage.getItem(`msal.${clientId}.https://graph.microsoft.com.idtoken`)).toBeNull();
+    });
+
+    test("removes keys that contain the clientId without the msal. prefix", () => {
+        const msalV3Key = `${clientId}-login.windows.net-accesstoken-${clientId}-organizations--`;
+        localStorage.setItem(msalV3Key, "tok");
+
+        MsalCacheUtils.clearStorageKeys(clientId);
+
+        expect(localStorage.getItem(msalV3Key)).toBeNull();
+    });
+
+    test("leaves keys for a different clientId untouched", () => {
+        localStorage.setItem(`msal.${otherClientId}.https://graph.microsoft.com.idtoken`, "tok");
+        sessionStorage.setItem(`msal.${otherClientId}.account.keys`, "v");
+
+        MsalCacheUtils.clearStorageKeys(clientId);
+
+        expect(localStorage.getItem(`msal.${otherClientId}.https://graph.microsoft.com.idtoken`)).toBe("tok");
+        expect(sessionStorage.getItem(`msal.${otherClientId}.account.keys`)).toBe("v");
+    });
+
+    test("leaves unrelated keys untouched", () => {
+        localStorage.setItem("theme", "dark");
+        sessionStorage.setItem("user-pref", "{}");
+
+        MsalCacheUtils.clearStorageKeys(clientId);
+
+        expect(localStorage.getItem("theme")).toBe("dark");
+        expect(sessionStorage.getItem("user-pref")).toBe("{}");
+    });
+});


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                            
  - Adds `clearCache(): Promise<void>` to `IAuthenticationService` and implements it on all four implementers.
  - Lets consumers reset broken MSAL state (expired/revoked cached tokens) via the public API instead of casting to private internals.
  - Extracts the shared clientId-keyed `localStorage`/`sessionStorage` cleanup into `MsalCacheUtils.clearStorageKeys()`.                                                                                                                                
                                                                                                                                                                                                                                                        
  ## Behavior                                                                                                                                                                                                                                           
  - Browser services (`Msal2`, `MSAL2Custom`, legacy `Msal`): clear `resourceTokenMap`, then strip clientId-keyed entries from both storages. `Msal2` additionally calls `msalObj.clearCache()`.                                                        
  - `NodeAppOnly`: recreates the `ConfidentialClientApplication` to drop its in-memory token cache. 